### PR TITLE
typo fix and added engine type blast

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ pasty --help
 ## Usage
 
 ```{bash}
- Usage: camlhmp-blast-region [OPTIONS]
+ Usage: camlhmp-blast-regions [OPTIONS]
 
- 🐪 camlhmp-blast-region 🐪 - Classify assemblies with a camlhmp schema using BLAST against
+ 🐪 camlhmp-blast-regions 🐪 - Classify assemblies with a camlhmp schema using BLAST against
  larger genomic regions
 
 ╭─ Options ─────────────────────────────────────────────────────────────────────────────────────╮

--- a/bin/pasty
+++ b/bin/pasty
@@ -3,5 +3,5 @@ pasty_dir=$(dirname $0)
 
 CAML_YAML="${pasty_dir}/../data/pa-osa.yaml" \
 CAML_TARGETS="${pasty_dir}/../data/pa-osa.fasta" \
-    camlhmp-blast-region \
+    camlhmp-blast-regions \
     "${@:1}"

--- a/bin/pasty-bioconda
+++ b/bin/pasty-bioconda
@@ -3,5 +3,5 @@ pasty_dir=$(dirname $0)
 
 CAML_YAML="${pasty_dir}/../share/pasty/pa-osa.yaml" \
 CAML_TARGETS="${pasty_dir}/../share/pasty/pa-osa.fasta" \
-    camlhmp-blast-region \
+    camlhmp-blast-regions \
     "${@:1}"

--- a/data/pa-osa.yaml
+++ b/data/pa-osa.yaml
@@ -12,6 +12,7 @@ metadata:
 # engine provides information about the tool and parameters used
 engine:
   tool: blastn # The tool used to generate the data
+  type: blast
 
 # targets provides a list of sequence targets (primers, genes, proteins, etc...)
 targets:


### PR DESCRIPTION
Running the current version always returns the error: "command not found: camlhmp-blast-region"
Small typo fix: camlhmp-blast-region -> camlhmp-blast-region**s**

Added engine type "blast" in yaml file. The absence of which raised a KeyError: 'type' at [this line](https://github.com/rpetit3/camlhmp/blob/1c99753f2be4b67eb4d1486ce2e12d4dc4479a19/camlhmp/cli/blast/regions.py#L191).